### PR TITLE
Refactor services to use explicit settings and enhance functionality

### DIFF
--- a/app/controller/speech_translator_pipeline.py
+++ b/app/controller/speech_translator_pipeline.py
@@ -44,7 +44,7 @@ class SpeechTranslatorPipeline(QObject):
         self._loop.start()
 
         self._pipeline = DualStreamPipeline(
-            name="top",
+            name=".",
             script_writer_callback=self._on_script,
             translated_script_writer_callback=self._on_translated,
             rms_callback=self._on_rms

--- a/logging.yaml
+++ b/logging.yaml
@@ -3,10 +3,10 @@ disable_existing_loggers: False
 
 formatters:
   simple:
-    format: "[%(asctime)s] [%(levelname)-7s] [%(name)s]: %(message)s"
+    format: "[%(asctime)s] [%(levelname)-7s] [%(name)-45s]: %(message)s"
 
   vpobj:
-    format: "[%(asctime)s] [%(levelname)-7s] [%(obj_path)-65s]: %(message)s"
+    format: "[%(asctime)s] [%(levelname)-7s] [%(obj_path)-45s]: %(message)s"
 
 handlers:
   console:
@@ -27,6 +27,21 @@ loggers:
     handlers: [vpobj_console]
     propagate: False
 
+  services:
+    level: INFO
+    handlers: [console]
+    propagate: False
+
+  httpx:
+    level: WARNING
+    handlers: [console]
+    propagate: False
+  
+  app:
+    level: INFO
+    handlers: [console]
+    propagate: False
+  
   services:
     level: INFO
     handlers: [console]

--- a/pipelines/augmented_speech_translator.py
+++ b/pipelines/augmented_speech_translator.py
@@ -52,8 +52,14 @@ class AugmentedSpeechTranslator(VpComposite):
 
     async def set_prop(self, prop, value):
         match prop:
-            case 'src-lang' | 'dest-lang' | 'asr-enable' | 'tts-enable':
+            case 'src-lang' | 'dest-lang' | 'asr-enable':
                 await self.get_capsule("speech-translator").set_prop(prop, value)
+            case 'tts-enable':
+                # immediately mute the TTS output if disabled
+                audio_mixer = self.get_capsule("audio-mixer")
+                audio_mixer.get_input("tts").set_property("mute", not value)
+                # set the TTS enable property in the speech translator
+                await self.get_capsule("speech-translator").set_prop("tts-enable", value)
             case 'src-volume':
                 self.get_capsule("audio-mixer").get_input("src").set_property('volume', value)
             case 'tts-volume':

--- a/pipelines/augmented_speech_translator.py
+++ b/pipelines/augmented_speech_translator.py
@@ -25,7 +25,7 @@ class AugmentedSpeechTranslator(VpComposite):
         src1 = src.fork()
         src2 = src.fork()
 
-        speech_translator = SpeechTranslator(name="speech-translator",
+        speech_translator = SpeechTranslator(name="st",
                                              src_lang=self.src_lang, dest_lang=self.dest_lang)
         audio_queue_player = VpAudioQueuePlayer(name="audio-queue-player")
         src1 >> speech_translator >> audio_queue_player
@@ -53,13 +53,13 @@ class AugmentedSpeechTranslator(VpComposite):
     async def set_prop(self, prop, value):
         match prop:
             case 'src-lang' | 'dest-lang' | 'asr-enable':
-                await self.get_capsule("speech-translator").set_prop(prop, value)
+                await self.get_capsule("st").set_prop(prop, value)
             case 'tts-enable':
                 # immediately mute the TTS output if disabled
                 audio_mixer = self.get_capsule("audio-mixer")
                 audio_mixer.get_input("tts").set_property("mute", not value)
                 # set the TTS enable property in the speech translator
-                await self.get_capsule("speech-translator").set_prop("tts-enable", value)
+                await self.get_capsule("st").set_prop("tts-enable", value)
             case 'src-volume':
                 self.get_capsule("audio-mixer").get_input("src").set_property('volume', value)
             case 'tts-volume':

--- a/pipelines/downstream_pipeline.py
+++ b/pipelines/downstream_pipeline.py
@@ -56,7 +56,7 @@ class DownStreamPipeline(VpPipeline):
         sink = VpSpeakerSink(name="speaker-sink")
         volume = VpVolume(name="volume-control")
         
-        translator = AugmentedSpeechTranslator(name="augmented-speech-translator",
+        translator = AugmentedSpeechTranslator(name="ast",
                                                src_lang='en', dest_lang='vi')
         rms_transform = VpRmsTransform(name="rms-transform")
 
@@ -88,7 +88,7 @@ class DownStreamPipeline(VpPipeline):
     async def set_prop(self, prop, value):
         match prop:
             case 'src-lang' | 'dest-lang' | 'src-volume' | 'tts-volume' | 'asr-enable' | 'tts-enable' | 'tts-speed':
-                await self.get_capsule("augmented-speech-translator").set_prop(prop, value)
+                await self.get_capsule("ast").set_prop(prop, value)
             case 'output-device':
                 sink = self.get_capsule("speaker-sink")
                 await sink.set_prop("device", value)

--- a/pipelines/selftalk_pipeline.py
+++ b/pipelines/selftalk_pipeline.py
@@ -49,7 +49,7 @@ class SelfTalkPipeline(VpPipeline):
     def build(self):
         src = VpMicSource()
         sink = VpSpeakerSink(name="speaker-sink")
-        translator = AugmentedSpeechTranslator(name="augmented-speech-translator",
+        translator = AugmentedSpeechTranslator(name="ast",
                                                src_lang='en', dest_lang='vi')
         src >> translator >> sink
 
@@ -71,6 +71,6 @@ class SelfTalkPipeline(VpPipeline):
     async def set_prop(self, prop, value):
         match prop:
             case 'src-lang' | 'dest-lang' | 'src-volume' | 'tts-volume':
-                await self.get_capsule("augmented-speech-translator").set_prop(prop, value)
+                await self.get_capsule("ast").set_prop(prop, value)
             case _:
                 raise ValueError(f"Unknown property: {prop}")

--- a/pipelines/upstream_pipeline.py
+++ b/pipelines/upstream_pipeline.py
@@ -2,6 +2,7 @@ import asyncio
 
 from vpipe.core.transform import VpBaseTransform
 from vpipe.core.pipeline import VpPipeline
+from vpipe.core.queue import VpQueue, DrainPolicy
 
 from vpipe.capsules.audio.virtual_mic_sink import VirtualMicSink
 from vpipe.capsules.audio.mic_source import VpMicSource
@@ -51,13 +52,14 @@ class UpStreamPipeline(VpPipeline):
 
     def build(self):
         src = VpMicSource(name="mic-src")
+        q1 = VpQueue(name='q1', maxsize=2, leaky=DrainPolicy.DOWNSTREAM)
         sink = VirtualMicSink(name="virtual-mic-sink")
         volume = VpVolume(name="volume-control")
         translator = AugmentedSpeechTranslator(name="augmented-speech-translator",
                                                src_lang='vi', dest_lang='en')
         rms_transform = VpRmsTransform(name="rms-transform")
 
-        src >> volume >> translator >> sink
+        src >> volume >> translator >> q1 >> sink
         src >> rms_transform
 
         script_writer = ScriptWriter(name="script-writer",
@@ -73,6 +75,7 @@ class UpStreamPipeline(VpPipeline):
 
         self.adds(
             src,
+            q1,
             sink,
             translator,
             volume,

--- a/pipelines/upstream_pipeline.py
+++ b/pipelines/upstream_pipeline.py
@@ -55,7 +55,7 @@ class UpStreamPipeline(VpPipeline):
         q1 = VpQueue(name='q1', maxsize=2, leaky=DrainPolicy.DOWNSTREAM)
         sink = VirtualMicSink(name="virtual-mic-sink")
         volume = VpVolume(name="volume-control")
-        translator = AugmentedSpeechTranslator(name="augmented-speech-translator",
+        translator = AugmentedSpeechTranslator(name="ast",
                                                src_lang='vi', dest_lang='en')
         rms_transform = VpRmsTransform(name="rms-transform")
 
@@ -87,7 +87,7 @@ class UpStreamPipeline(VpPipeline):
     async def set_prop(self, prop, value):
         match prop:
             case 'src-lang' | 'dest-lang' | 'src-volume' | 'tts-volume' | 'asr-enable' | 'tts-enable' | 'tts-speed':
-                await self.get_capsule("augmented-speech-translator").set_prop(prop, value)
+                await self.get_capsule("ast").set_prop(prop, value)
             case 'input-device':
                 src = self.get_capsule("mic-src")
                 await src.set_prop("device", value)

--- a/services/services/deepgram_asr_service.py
+++ b/services/services/deepgram_asr_service.py
@@ -14,7 +14,7 @@ LANG_MODEL_MAP = {
 
 class DeepGramASRService(ASRServiceInterface):
     def __init__(self, lang='en', settings={}):
-        logger.info(f"Initializing Deepgram ASR service with lang: {lang}, settings: {settings}")
+        logger.debug(f"Initializing Deepgram ASR service with lang: {lang}, settings: {settings}")
         self.lang = lang if lang in LANG_MODEL_MAP else "en"
         self.model = LANG_MODEL_MAP[self.lang]["model"]
         self.language = LANG_MODEL_MAP[self.lang]["language"]

--- a/services/services/deepgram_asr_service.py
+++ b/services/services/deepgram_asr_service.py
@@ -13,16 +13,15 @@ LANG_MODEL_MAP = {
 }
 
 class DeepGramASRService(ASRServiceInterface):
-    def __init__(self, *args, **kwargs):
-        logger.info(f"Initializing Deepgram ASR service with args: {args}, kwargs: {kwargs}")
-        lang = kwargs.get("lang", "en")
+    def __init__(self, lang='en', settings={}):
+        logger.info(f"Initializing Deepgram ASR service with lang: {lang}, settings: {settings}")
         self.lang = lang if lang in LANG_MODEL_MAP else "en"
         self.model = LANG_MODEL_MAP[self.lang]["model"]
         self.language = LANG_MODEL_MAP[self.lang]["language"]
-        self.utterance_end_ms = int(kwargs.get("utterance_end_ms", "1024"))
-        self.endpointing = int(kwargs.get("endpointing", "300"))
+        self.utterance_end_ms = int(settings.get("utterance_end_ms", "1024"))
+        self.endpointing = int(settings.get("endpointing", "300"))
 
-        self.client = DeepgramClient(api_key=kwargs.get("api_key") or "")
+        self.client = DeepgramClient(api_key=settings.get("api_key") or "")
         self.conn = self.client.listen.asyncwebsocket.v("1")
         self.recv_queue = asyncio.Queue()
         self.buffer = bytearray()

--- a/services/services/google_translator_service.py
+++ b/services/services/google_translator_service.py
@@ -3,7 +3,7 @@ from googletrans import Translator
 from vpipe.capsules.services.tran import TranslatorServiceInterface
 
 class GoogleTranslatorService(TranslatorServiceInterface):
-    def __init__(self, **kwargs):
+    def __init__(self, settings={}):
         self.translator = None
 
     def initialize(self):

--- a/services/services/google_tts_service.py
+++ b/services/services/google_tts_service.py
@@ -6,7 +6,7 @@ import numpy as np
 from vpipe.capsules.services.tts import TTSServiceInterface
 
 class GoogleTTSService(TTSServiceInterface):
-    def __init__(self, **kwargs):
+    def __init__(self, settings={}):
         pass
     
     async def start(self):

--- a/services/services/local_nllb_translator_service.py
+++ b/services/services/local_nllb_translator_service.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 class LocalNLLBTranslatorService(TranslatorServiceInterface):
     def __init__(self, settings={}):
-        logger.info(f"Initializing LocalNLLBTranslatorService with settings: {settings}")
+        logger.debug(f"Initializing LocalNLLBTranslatorService with settings: {settings}")
         self.base_url = settings.get('url', 'http://10.133.134.206:8011')
         self.client = None
 

--- a/services/services/local_nllb_translator_service.py
+++ b/services/services/local_nllb_translator_service.py
@@ -5,9 +5,9 @@ from vpipe.capsules.services.tran import TranslatorServiceInterface
 logger = logging.getLogger(__name__)
 
 class LocalNLLBTranslatorService(TranslatorServiceInterface):
-    def __init__(self, *args, **kwargs):
-        logger.info(f"Initializing LocalNLLBTranslatorService with args: {args}, kwargs: {kwargs}")
-        self.base_url = kwargs.get('url', 'http://10.133.134.206:8011')
+    def __init__(self, settings={}):
+        logger.info(f"Initializing LocalNLLBTranslatorService with settings: {settings}")
+        self.base_url = settings.get('url', 'http://10.133.134.206:8011')
         self.client = None
 
     async def start(self):

--- a/services/services/whisper_asr_service.py
+++ b/services/services/whisper_asr_service.py
@@ -18,13 +18,10 @@ logger = logging.getLogger(__name__)
 
 
 class WhisperASRService(ASRServiceInterface):
-    def __init__(self, *args: Any, **kwargs: Any):
-        lang = kwargs.get("lang", "en")
-        url = kwargs.get("url", SERVER_URL)
-
+    def __init__(self, lang='en', settings={}):
         if lang not in LANG_MODEL_MAP:
             raise ValueError(f"Unsupported language: {lang}")
-        self.server_url = url
+        self.server_url = settings.get("url", SERVER_URL)
         self.language = LANG_MODEL_MAP[lang]["language"]
 
         self._ws = None

--- a/services/services/whisper_asr_service.py
+++ b/services/services/whisper_asr_service.py
@@ -36,6 +36,10 @@ class WhisperASRService(ASRServiceInterface):
         self._started = False
         self._stopped = True
 
+    async def switch_lang(self, lang):
+        """ Support dynamic language switching """
+        self.language = LANG_MODEL_MAP.get(lang, LANG_MODEL_MAP["en"])["language"]
+
     async def start(self):
         if self._starting or self._started:
             return

--- a/services/services/xtts_tts_service.py
+++ b/services/services/xtts_tts_service.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 class XttsTTSService(TTSServiceInterface):
     def __init__(self, settings={}):
-        logger.info(f"Initializing Xtts TTS service with settings: {settings}")
+        logger.debug(f"Initializing Xtts TTS service with settings: {settings}")
         self.server_url = settings.get("url", SERVER_URL)
         self.websocket = None
         self.default_speakers = {

--- a/services/services/xtts_tts_service.py
+++ b/services/services/xtts_tts_service.py
@@ -14,9 +14,9 @@ logger = logging.getLogger(__name__)
 
 
 class XttsTTSService(TTSServiceInterface):
-    def __init__(self, *args, **kwargs):
-        logger.info(f"Initializing Xtts TTS service with args: {args}, kwargs: {kwargs}")
-        self.server_url = kwargs.get("url", SERVER_URL)
+    def __init__(self, settings={}):
+        logger.info(f"Initializing Xtts TTS service with settings: {settings}")
+        self.server_url = settings.get("url", SERVER_URL)
         self.websocket = None
         self.default_speakers = {
             'vi': "ref/vi_male.wav", 

--- a/vpipe/capsules/services/asr.py
+++ b/vpipe/capsules/services/asr.py
@@ -6,6 +6,11 @@ from vpipe.core.transform import VpBaseTransform
 
 class ASRServiceInterface(ABC):
     @abstractmethod
+    def __init__(self, lang='en', settings={}):
+        """Initialize the ASR service with the specified language and settings."""
+        pass
+
+    @abstractmethod
     async def start(self):
         """Start the ASR service."""
         pass
@@ -31,6 +36,12 @@ class ASRServiceInterface(ABC):
                 - is_final (bool): True if this is a final result, False if partial/intermediate.
         """
         pass
+        
+    async def switch_lang(self, lang):
+        """
+        Implement this method if the service supports dynamic language switching.
+        """
+        raise NotImplementedError("This service does not support language setting at runtime.")
 
 
 class ASRTransform(VpBaseTransform):
@@ -39,24 +50,54 @@ class ASRTransform(VpBaseTransform):
     service connection alive
     future: delegate to service if it supports dynamic enabling/disabling
     """
-    def __init__(self, name, service_factory):
+    def __init__(self, name, service_factory, lang='en'):
         super().__init__(name=name)
         self.service_factory = service_factory
         self.service = None
         self.enable = True
+        self.lang = lang
 
     def set_service(self, service: ASRServiceInterface):
         self.service = service
 
-    def set_prop(self, key, value):
+    async def set_prop(self, key, value):
         match key:
             case "enable":
                 self.enable = value
+            case "lang":
+                self.lang = value
+                # 1. If service is not started, nothing to do
+                if not self.service:
+                    return
+                # 2. At this point, service is already started
+                # -> Try to switch language if supported
+                try:
+                    await self.service.switch_lang(value)
+                # 3. Fail to switch language, don't care the reason
+                #    (service does not support language switching, switching failed, ...)
+                # -> Restart service to apply new language setting
+                except Exception as e:
+                    self.logger.warning(f"Can not switch language dynamically")
+                    self.logger.warning(f"Try to restart service to apply new language")
+                    # Restart service to apply new language setting
+                    await self._restart_service()
+                
             case _:
                 raise AttributeError(f"Unknown property: {key}")
 
+    async def _restart_service(self):
+        if not self.service:
+            self.logger.warning("Service is not started, cannot restart.")
+            return
+        
+        enabled = self.enable
+        self.enable = False
+        await self.stop()
+        await self.start()
+        self.enable = enabled
+
     async def start(self):
-        self.service = self.service_factory()
+        self.service = self.service_factory(lang=self.lang)
         self.logger.info(f"Starting ASR service: {self.service.__class__.__name__}")
         await self.service.start()
         self.logger.info(f"ASR service {self.service.__class__.__name__} started")

--- a/vpipe/capsules/services/tran.py
+++ b/vpipe/capsules/services/tran.py
@@ -4,6 +4,11 @@ from vpipe.core.transform import VpBaseTransform
 
 class TranslatorServiceInterface(ABC):
     @abstractmethod
+    def __init__(self, settings={}):
+        """Initialize the translator service with optional settings."""
+        pass
+
+    @abstractmethod
     async def start(self):
         """Start the translator service."""
         pass
@@ -30,7 +35,7 @@ class TranslationTransform(VpBaseTransform):
     def set_service(self, service: TranslatorServiceInterface):
         self.service = service
 
-    def set_prop(self, key: str, value):
+    async def set_prop(self, key: str, value):
         match key:
             case 'src-lang':
                 self.src = value
@@ -49,7 +54,7 @@ class TranslationTransform(VpBaseTransform):
                 raise ValueError(f"Unknown property: {key}")
 
     async def start(self):
-        self.service = self.service_factory() if self.service_factory else self.service
+        self.service = self.service_factory()
         self.logger.info(f"Starting translation service: {self.service.__class__.__name__}")
         await self.service.start()
         self.logger.info(f"Translation service {self.service.__class__.__name__} started")

--- a/vpipe/capsules/services/tts.py
+++ b/vpipe/capsules/services/tts.py
@@ -4,6 +4,11 @@ from vpipe.core.transform import VpBaseTransform
 
 class TTSServiceInterface(ABC):
     @abstractmethod
+    def __init__(self, settings={}):
+        """Initialize the tts service with optional settings."""
+        pass
+
+    @abstractmethod
     async def start(self):
         """Start the TTS service."""
         pass
@@ -35,7 +40,7 @@ class TTSTransform(VpBaseTransform):
     def set_service(self, service: TTSServiceInterface):
         self.service = service
 
-    def set_prop(self, key: str, value):
+    async def set_prop(self, key: str, value):
         match key:
             case 'lang':
                 self.lang = value
@@ -44,7 +49,7 @@ class TTSTransform(VpBaseTransform):
             case _:
                 raise ValueError(f"Unknown property: {key}")
     
-    def get_prop(self, key: str):
+    async def get_prop(self, key: str):
         match key:
             case 'lang':
                 return self.lang
@@ -52,7 +57,7 @@ class TTSTransform(VpBaseTransform):
                 raise ValueError(f"Unknown property: {key}")
 
     async def start(self):
-        self.service = self.service_factory() if self.service_factory else self.service
+        self.service = self.service_factory()
         self.logger.info(f"Starting TTS service: {self.service.__class__.__name__}")
         await self.service.start()
         self.logger.info(f"TTS service {self.service.__class__.__name__} started")


### PR DESCRIPTION
- Refactored service initialization to use an explicit settings object instead of scattered keyword arguments.
- Added support for dynamic language switching via the switch_lang method.
- Improved logging for better readability and context.
- Fixbug: pipeline can be block by virtual mic sink